### PR TITLE
set showprogress=False for bestsource

### DIFF
--- a/src/shared/WobblyProject.cpp
+++ b/src/shared/WobblyProject.cpp
@@ -4130,7 +4130,7 @@ void WobblyProject::presetsToScript(std::string &script) const {
 
 const char *WobblyProject::getArgsForSourceFilter() const {
     if (source_filter == "bs.VideoSource")
-        return ", rff=True";
+        return ", rff=True, showprogress=False";
     return "";
 }
 

--- a/src/wibbly/WibblyJob.cpp
+++ b/src/wibbly/WibblyJob.cpp
@@ -237,7 +237,7 @@ void WibblyJob::headerToScript(std::string &script) const {
 
 const char *WibblyJob::getArgsForSourceFilter() const {
     if (source_filter == "bs.VideoSource")
-        return ", rff=True";
+        return ", rff=True, showprogress=False";
     return "";
 }
 

--- a/src/wobbly/WobblyWindow.cpp
+++ b/src/wobbly/WobblyWindow.cpp
@@ -3880,7 +3880,7 @@ void WobblyWindow::openProject() {
 
 const char *WobblyWindow::getArgsForSourceFilter(const QString &source_filter) {
     if (source_filter == "bs.VideoSource")
-        return ", rff=True";
+        return ", rff=True, showprogress=False";
     return "";
 }
 


### PR DESCRIPTION
Recent [bestsource](https://github.com/vapoursynth/bestsource/commit/dd03bc8e1ed6a667d9a48d09f7221f4255afac2f) has enable progress reporting by default. The logging implementation of wibbly opens popups for messages which seems to halt indexing progress.