### PR TITLE
Fix findFreezeFrame OOB read causing phantom freeze-frame reports

### DIFF
--- a/src/shared/WobblyProject.cpp
+++ b/src/shared/WobblyProject.cpp
@@ -1517,10 +1517,10 @@ void WobblyProject::deleteFreezeFrame(int frame) {
 
 
 const FreezeFrame *WobblyProject::findFreezeFrame(int frame) const {
-    if (!frozen_frames->size())
-        return nullptr;
-
     auto it = frozen_frames->upper_bound(frame);
+
+    if (it == frozen_frames->cbegin())
+        return nullptr;
 
     it--;
 


### PR DESCRIPTION
The phantom frozen frame range is shown in the frame details pane/overlay and prevents adding real frozen frames that overlap it.

Happens when you’re looking at a frame that’s earlier than any real freeze and some data in RAM just happens to look like a plausible even-smaller signed integer.